### PR TITLE
Remove period from tooltip labels.

### DIFF
--- a/src/Views/General.vala
+++ b/src/Views/General.vala
@@ -81,7 +81,7 @@ public class MouseTouchpad.GeneralView : Gtk.Grid {
         var hold_switch = new Gtk.Switch ();
         hold_switch.halign = Gtk.Align.START;
 
-        var hold_help = new Gtk.Label (_("Long-pressing and releasing the primary button will secondary click."));
+        var hold_help = new Gtk.Label (_("Long-pressing and releasing the primary button will secondary click"));
         hold_help.margin_bottom = 18;
         hold_help.wrap = true;
         hold_help.xalign = 0;
@@ -109,7 +109,7 @@ public class MouseTouchpad.GeneralView : Gtk.Grid {
         pointer_speed_scale.draw_value = false;
         pointer_speed_scale.add_mark (10, Gtk.PositionType.TOP, null);
 
-        var pointer_speed_help = new Gtk.Label (_("This disables both levels of keys on the numeric keypad."));
+        var pointer_speed_help = new Gtk.Label (_("This disables both levels of keys on the numeric keypad"));
         pointer_speed_help.margin_bottom = 18;
 
         pointer_speed_help.wrap = true;


### PR DESCRIPTION
Not super sure if i need to change the text in all of the translation files. This should remove the period(s) in the tooltip labels:

![Screenshot from 2019-09-13 19 37 59](https://user-images.githubusercontent.com/8471701/64900269-032c1000-d65e-11e9-8de9-209b11c98544.png)

Resolves https://github.com/elementary/switchboard-plug-mouse-touchpad/issues/80