### PR TITLE
Fix Middle click setting not showing up

### DIFF
--- a/src/Views/General.vala
+++ b/src/Views/General.vala
@@ -138,7 +138,7 @@ public class MouseTouchpad.GeneralView : Gtk.Grid {
         attach (pointer_speed_scale, 3, 8);
         attach (pointer_speed_help, 1, 9, 3);
 
-        var xsettings_schema = SettingsSchemaSource.get_default ().lookup ("org.gnome.settings-daemon.plugins.xsettings", false);
+        var xsettings_schema = SettingsSchemaSource.get_default ().lookup ("org.gnome.settings-daemon.plugins.xsettings", true);
         if (xsettings_schema != null) {
             var primary_paste_switch = new Gtk.Switch ();
             primary_paste_switch.halign = Gtk.Align.START;


### PR DESCRIPTION
The middle click on paste setting was not showing up on my system as _SettingsSchemaSource.get_default ().lookup ()_  was returning null unless I set _recursive_ argument to **true** to lookup in parent sources.