### PR TITLE
Add more markers to the pointer speed scale

### DIFF
--- a/src/Views/Mouse.vala
+++ b/src/Views/Mouse.vala
@@ -33,6 +33,7 @@ public class MouseTouchpad.MouseView : Granite.SimpleSettingsPage {
         pointer_speed_scale.draw_value = false;
         pointer_speed_scale.hexpand = true;
         pointer_speed_scale.width_request = 160;
+        pointer_speed_scale.add_mark (0, Gtk.PositionType.TOP, null);
         for (double x = -0.75; x < 1; x += 0.25) {
             pointer_speed_scale.add_mark (x, Gtk.PositionType.BOTTOM, null);
         }

--- a/src/Views/Mouse.vala
+++ b/src/Views/Mouse.vala
@@ -33,7 +33,9 @@ public class MouseTouchpad.MouseView : Granite.SimpleSettingsPage {
         pointer_speed_scale.draw_value = false;
         pointer_speed_scale.hexpand = true;
         pointer_speed_scale.width_request = 160;
-        pointer_speed_scale.add_mark (0, Gtk.PositionType.BOTTOM, null);
+        for (double x = -0.75; x < 1; x += 0.25) {
+            pointer_speed_scale.add_mark (x, Gtk.PositionType.BOTTOM, null);
+        }
 
         var accel_profile_default = new Gtk.RadioButton.with_label (null, _("Hardware default"));
         var accel_profile_flat = new Gtk.RadioButton.with_label_from_widget (accel_profile_default, _("None"));

--- a/src/Views/Mouse.vala
+++ b/src/Views/Mouse.vala
@@ -33,9 +33,9 @@ public class MouseTouchpad.MouseView : Granite.SimpleSettingsPage {
         pointer_speed_scale.draw_value = false;
         pointer_speed_scale.hexpand = true;
         pointer_speed_scale.width_request = 160;
-        pointer_speed_scale.add_mark (0, Gtk.PositionType.TOP, null);
+        pointer_speed_scale.add_mark (0, Gtk.PositionType.BOTTOM, null);
         for (double x = -0.75; x < 1; x += 0.25) {
-            pointer_speed_scale.add_mark (x, Gtk.PositionType.BOTTOM, null);
+            pointer_speed_scale.add_mark (x, Gtk.PositionType.TOP, null);
         }
 
         var accel_profile_default = new Gtk.RadioButton.with_label (null, _("Hardware default"));

--- a/src/Views/Touchpad.vala
+++ b/src/Views/Touchpad.vala
@@ -59,9 +59,9 @@ public class MouseTouchpad.TouchpadView : Granite.SimpleSettingsPage {
         var pointer_speed_scale = new Gtk.Scale (Gtk.Orientation.HORIZONTAL, pointer_speed_adjustment);
         pointer_speed_scale.digits = 2;
         pointer_speed_scale.draw_value = false;
-        pointer_speed_scale.add_mark (0, Gtk.PositionType.TOP, null);
+        pointer_speed_scale.add_mark (0, Gtk.PositionType.BOTTOM, null);
         for (double x = -0.75; x < 1; x += 0.25) {
-            pointer_speed_scale.add_mark (x, Gtk.PositionType.BOTTOM, null);
+            pointer_speed_scale.add_mark (x, Gtk.PositionType.TOP, null);
         }
 
         var scrolling_combobox = new Gtk.ComboBoxText ();

--- a/src/Views/Touchpad.vala
+++ b/src/Views/Touchpad.vala
@@ -59,7 +59,9 @@ public class MouseTouchpad.TouchpadView : Granite.SimpleSettingsPage {
         var pointer_speed_scale = new Gtk.Scale (Gtk.Orientation.HORIZONTAL, pointer_speed_adjustment);
         pointer_speed_scale.digits = 2;
         pointer_speed_scale.draw_value = false;
-        pointer_speed_scale.add_mark (0, Gtk.PositionType.BOTTOM, null);
+        for (double x = -0.75; x < 1; x += 0.25) {
+            pointer_speed_scale.add_mark (x, Gtk.PositionType.BOTTOM, null);
+        }
 
         var scrolling_combobox = new Gtk.ComboBoxText ();
         scrolling_combobox.append ("two-finger-scrolling", _("Two-finger"));

--- a/src/Views/Touchpad.vala
+++ b/src/Views/Touchpad.vala
@@ -59,6 +59,7 @@ public class MouseTouchpad.TouchpadView : Granite.SimpleSettingsPage {
         var pointer_speed_scale = new Gtk.Scale (Gtk.Orientation.HORIZONTAL, pointer_speed_adjustment);
         pointer_speed_scale.digits = 2;
         pointer_speed_scale.draw_value = false;
+        pointer_speed_scale.add_mark (0, Gtk.PositionType.TOP, null);
         for (double x = -0.75; x < 1; x += 0.25) {
             pointer_speed_scale.add_mark (x, Gtk.PositionType.BOTTOM, null);
         }


### PR DESCRIPTION
This makes it easier to set a consistent pointer speed across different machines, which is important for graphical applications (e.g. GIMP, Inkscape, Figma, ...). I also sometimes set the pointer speed temporarily super low to sign documents. And after that it is only possible via gsettings to reproduce the exact previous pointer speed. I assume this could also be useful for gamers, which also rely on a consistent pointer speed. 

