### PR TITLE
adapt to GSettings schema changes in GNOME 40

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -17,6 +17,10 @@ add_project_arguments(
     language:'c'
 )
 
+if get_option('gnome_40')
+    add_project_arguments(['--define', 'HAS_GNOME_40'], language: 'vala')
+endif
+
 icon_res = gnome.compile_resources(
     'icon-resources',
     join_paths('data', 'io.elementary.switchboard.' + meson.project_name() + '.gresource.xml'),

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,1 @@
+option('gnome_40', type : 'boolean', value : false)

--- a/src/Views/Clicking.vala
+++ b/src/Views/Clicking.vala
@@ -170,8 +170,10 @@ public class MouseTouchpad.ClickingView : Granite.SimpleSettingsPage {
             }
         }
 
+#if !HAS_GNOME_40
         var daemon_settings = new GLib.Settings ("org.gnome.settings-daemon.peripherals.mouse");
         daemon_settings.bind ("double-click", double_click_speed_adjustment, "value", SettingsBindFlags.DEFAULT);
+#endif
 
         var a11y_mouse_settings = new GLib.Settings ("org.gnome.desktop.a11y.mouse");
         a11y_mouse_settings.bind (
@@ -196,6 +198,11 @@ public class MouseTouchpad.ClickingView : Granite.SimpleSettingsPage {
         hold_switch.bind_property ("active", hold_spin_grid, "sensitive", BindingFlags.SYNC_CREATE);
 
         var mouse_settings = new GLib.Settings ("org.gnome.desktop.peripherals.mouse");
+
+#if HAS_GNOME_40
+        mouse_settings.bind ("double-click", double_click_speed_adjustment, "value", SettingsBindFlags.DEFAULT);
+#endif
+
         if (mouse_settings.get_boolean ("left-handed")) {
             mouse_right.active = true;
         } else {


### PR DESCRIPTION
The "double-click" GSetting key has moved from the `org.gnome.settings-daemon.mouse` to the `org.gnome.desktop.mouse` schema in GNOME 40. To support both the old and the new version, conditional compilation is used.

There's no dependency that I could `version_compare` with to check if it's GNOME 40, so I used a new meson option instead.

The patch seems to work as intended on top of both GNOME 3.38 and 40, and does not change the default behaviour.