### PR TITLE
Clicking: drop support for old GNOME Settings Daemon

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     
     container:
-      image: elementary/docker:unstable
+      image: elementary/docker:next-unstable
     
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Install Dependencies
       run: |
         apt update
@@ -32,6 +32,6 @@ jobs:
       image: valalang/lint
       
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Lint
       run: io.elementary.vala-lint -d .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,4 +16,4 @@ jobs:
          GIT_USER_NAME: "elementaryBot"
          GIT_USER_EMAIL: "builds@elementary.io"
        with:
-         release_branch: 'odin'
+         release_branch: 'jammy'

--- a/meson.build
+++ b/meson.build
@@ -17,10 +17,6 @@ add_project_arguments(
     language:'c'
 )
 
-if get_option('gnome_40')
-    add_project_arguments(['--define', 'HAS_GNOME_40'], language: 'vala')
-endif
-
 icon_res = gnome.compile_resources(
     'icon-resources',
     join_paths('data', 'io.elementary.switchboard.' + meson.project_name() + '.gresource.xml'),

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,1 +1,0 @@
-option('gnome_40', type : 'boolean', value : false)

--- a/src/Views/Clicking.vala
+++ b/src/Views/Clicking.vala
@@ -170,11 +170,6 @@ public class MouseTouchpad.ClickingView : Granite.SimpleSettingsPage {
             }
         }
 
-#if !HAS_GNOME_40
-        var daemon_settings = new GLib.Settings ("org.gnome.settings-daemon.peripherals.mouse");
-        daemon_settings.bind ("double-click", double_click_speed_adjustment, "value", SettingsBindFlags.DEFAULT);
-#endif
-
         var a11y_mouse_settings = new GLib.Settings ("org.gnome.desktop.a11y.mouse");
         a11y_mouse_settings.bind (
             "secondary-click-enabled",
@@ -198,10 +193,7 @@ public class MouseTouchpad.ClickingView : Granite.SimpleSettingsPage {
         hold_switch.bind_property ("active", hold_spin_grid, "sensitive", BindingFlags.SYNC_CREATE);
 
         var mouse_settings = new GLib.Settings ("org.gnome.desktop.peripherals.mouse");
-
-#if HAS_GNOME_40
         mouse_settings.bind ("double-click", double_click_speed_adjustment, "value", SettingsBindFlags.DEFAULT);
-#endif
 
         if (mouse_settings.get_boolean ("left-handed")) {
             mouse_right.active = true;


### PR DESCRIPTION
Shift development focus to jammy. Fixes a crash in OS 7