### PR TITLE
Touchpad: use vertical layout, cleanup

### DIFF
--- a/src/Views/Touchpad.vala
+++ b/src/Views/Touchpad.vala
@@ -79,9 +79,7 @@ public class MouseTouchpad.TouchpadView : Granite.SimpleSettingsPage {
         tap_box.append (tap_to_click_check);
         tap_box.append (tap_and_drag_check);
 
-        var scroll_method_label = new Granite.HeaderLabel (_("Scroll Method")) {
-            margin_top = 12
-        };
+        var scroll_method_label = new Granite.HeaderLabel (_("Scroll Method"));
 
         var two_finger_scroll_radio = new Gtk.CheckButton ();
         two_finger_scroll_radio.add_css_class ("image-button");
@@ -144,15 +142,16 @@ public class MouseTouchpad.TouchpadView : Granite.SimpleSettingsPage {
         var content_box = new Gtk.Box (VERTICAL, 6);
         content_box.append (pointer_speed_header);
         content_box.append (pointer_speed_scale);
-        content_box.append (click_method_label);
-        content_box.append (click_method_box);
+        content_box.append (disable_label);
+        content_box.append (disable_box);
         content_box.append (new Granite.HeaderLabel (_("Tapping")));
         content_box.append (tap_box);
+        content_box.append (click_method_label);
+        content_box.append (click_method_box);
         content_box.append (scroll_method_label);
         content_box.append (scroll_method_box);
         content_box.append (natural_scrolling_box);
-        content_box.append (disable_label);
-        content_box.append (disable_box);
+
 
         content_area.attach (content_box, 0, 0);
 

--- a/src/Views/Touchpad.vala
+++ b/src/Views/Touchpad.vala
@@ -1,20 +1,6 @@
 /*
- * Copyright 2011-2021 elementary, Inc. (https://elementary.io)
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation; either
- * version 2 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * General Public License for more details.
- *
- * You should have received a copy of the GNU General Public
- * License along with this program; if not, write to the
- * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
- * Boston, MA 02110-1301 USA.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ * SPDX-FileCopyrightText: 2011-2024 elementary, Inc. (https://elementary.io)
  */
 
 public class MouseTouchpad.TouchpadView : Granite.SimpleSettingsPage {
@@ -33,16 +19,18 @@ public class MouseTouchpad.TouchpadView : Granite.SimpleSettingsPage {
     construct {
         var pointer_speed_adjustment = new Gtk.Adjustment (0, -1, 1, 0.1, 0, 0);
 
-        var pointer_speed_scale = new Gtk.Scale (Gtk.Orientation.HORIZONTAL, pointer_speed_adjustment) {
+        var pointer_speed_scale = new Gtk.Scale (HORIZONTAL, pointer_speed_adjustment) {
             digits = 2,
             draw_value = false,
             hexpand = true
         };
+        pointer_speed_scale.add_mark (-1, BOTTOM, _("Slower"));
+        pointer_speed_scale.add_mark (0, BOTTOM, null);
+        pointer_speed_scale.add_mark (1, BOTTOM, _("Faster"));
 
-        pointer_speed_scale.add_mark (0, Gtk.PositionType.BOTTOM, null);
-        for (double x = -0.75; x < 1; x += 0.25) {
-            pointer_speed_scale.add_mark (x, Gtk.PositionType.TOP, null);
-        }
+        var pointer_speed_header = new Granite.HeaderLabel (_("Pointer Speed")) {
+            mnemonic_widget = pointer_speed_scale
+        };
 
         multitouch_click_method_radio = new Gtk.CheckButton ();
         multitouch_click_method_radio.add_css_class ("image-button");
@@ -53,7 +41,7 @@ public class MouseTouchpad.TouchpadView : Granite.SimpleSettingsPage {
             pixel_size = 32
         };
 
-        var multitouch_click_method_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
+        var multitouch_click_method_box = new Gtk.Box (VERTICAL, 0);
         multitouch_click_method_box.append (multitouch_click_method_image);
         multitouch_click_method_box.append (multitouch_click_method_label);
         multitouch_click_method_box.set_parent (multitouch_click_method_radio);
@@ -68,19 +56,14 @@ public class MouseTouchpad.TouchpadView : Granite.SimpleSettingsPage {
             pixel_size = 32
         };
 
-        var areas_click_method_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
+        var areas_click_method_box = new Gtk.Box (VERTICAL, 0);
         areas_click_method_box.append (areas_click_method_image);
         areas_click_method_box.append (areas_click_method_label);
         areas_click_method_box.set_parent (areas_click_method_radio);
 
-        var click_method_label = new Gtk.Label (_("Physical secondary clicking:")) {
-            margin_top = 24,
-            halign = Gtk.Align.END
-        };
+        var click_method_label = new Granite.HeaderLabel (_("Physical Secondary Clicking"));
 
-        var click_method_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 12) {
-            margin_top = 24
-        };
+        var click_method_box = new Gtk.Box (HORIZONTAL, 12);
         click_method_box.append (multitouch_click_method_radio);
         click_method_box.append (areas_click_method_radio);
 
@@ -92,13 +75,12 @@ public class MouseTouchpad.TouchpadView : Granite.SimpleSettingsPage {
             halign = Gtk.Align.START
         };
 
-        var tap_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 12);
+        var tap_box = new Gtk.Box (HORIZONTAL, 24);
         tap_box.append (tap_to_click_check);
         tap_box.append (tap_and_drag_check);
 
-        var scroll_method_label = new Gtk.Label (_("Scroll method:")) {
-            margin_top = 24,
-            halign = Gtk.Align.END
+        var scroll_method_label = new Granite.HeaderLabel (_("Scroll Method")) {
+            margin_top = 12
         };
 
         var two_finger_scroll_radio = new Gtk.CheckButton ();
@@ -109,7 +91,7 @@ public class MouseTouchpad.TouchpadView : Granite.SimpleSettingsPage {
             pixel_size = 32
         };
 
-        var two_finger_scroll_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
+        var two_finger_scroll_box = new Gtk.Box (VERTICAL, 0);
         two_finger_scroll_box.append (two_finger_scroll_image);
         two_finger_scroll_box.append (two_finger_scroll_label);
         two_finger_scroll_box.set_parent (two_finger_scroll_radio);
@@ -124,82 +106,86 @@ public class MouseTouchpad.TouchpadView : Granite.SimpleSettingsPage {
             pixel_size = 32
         };
 
-        var edge_scroll_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
+        var edge_scroll_box = new Gtk.Box (VERTICAL, 0);
         edge_scroll_box.append (edge_scroll_image);
         edge_scroll_box.append (edge_scroll_label);
         edge_scroll_box.set_parent (edge_scroll_radio);
 
-        var scroll_method_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 12) {
-            margin_top = 24
-        };
+        var scroll_method_box = new Gtk.Box (HORIZONTAL, 24);
         scroll_method_box.append (two_finger_scroll_radio);
         scroll_method_box.append (edge_scroll_radio);
 
-        var natural_scrolling_label = new Gtk.Label (_("Natural scrolling:")) {
-            halign = Gtk.Align.END
-        };
-
         var natural_scrolling_switch = new Gtk.Switch () {
-            halign = Gtk.Align.START
+            halign = END,
+            hexpand = true,
+            valign = CENTER
         };
 
-        var disable_label = new Gtk.Label (_("Ignore:")) {
-            margin_top = 24,
-            halign = Gtk.Align.END
+        var natural_scrolling_header = new Granite.HeaderLabel (_("Natural Scrolling")) {
+            mnemonic_widget = natural_scrolling_switch,
+            secondary_text = _("Scrolling moves the content, not the view")
         };
+
+        var natural_scrolling_box = new Gtk.Box (HORIZONTAL, 12) {
+            margin_top = 12
+        };
+        natural_scrolling_box.append (natural_scrolling_header);
+        natural_scrolling_box.append (natural_scrolling_switch);
+
+        var disable_label = new Granite.HeaderLabel (_("Ignore"));
 
         var disable_while_typing_check = new Gtk.CheckButton.with_label (_("While typing"));
         var disable_with_mouse_check = new Gtk.CheckButton.with_label (_("When mouse is connected"));
 
-        var disable_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 12) {
-            margin_top = 24
-        };
+        var disable_box = new Gtk.Box (HORIZONTAL, 24);
         disable_box.append (disable_while_typing_check);
         disable_box.append (disable_with_mouse_check);
 
-        content_area.attach (new Gtk.Label (_("Pointer speed:")) { halign = Gtk.Align.END }, 0, 0);
-        content_area.attach (pointer_speed_scale, 1, 0);
-        content_area.attach (click_method_label, 0, 1);
-        content_area.attach (click_method_box, 1, 1);
-        content_area.attach (new Gtk.Label (_("Tapping:")) { halign = Gtk.Align.END }, 0, 2);
-        content_area.attach (tap_box, 1, 2);
-        content_area.attach (scroll_method_label, 0, 3);
-        content_area.attach (scroll_method_box, 1, 3);
-        content_area.attach (natural_scrolling_label, 0, 4);
-        content_area.attach (natural_scrolling_switch, 1, 4);
-        content_area.attach (disable_label, 0, 5);
-        content_area.attach (disable_box, 1, 5);
+        var content_box = new Gtk.Box (VERTICAL, 6);
+        content_box.append (pointer_speed_header);
+        content_box.append (pointer_speed_scale);
+        content_box.append (click_method_label);
+        content_box.append (click_method_box);
+        content_box.append (new Granite.HeaderLabel (_("Tapping")));
+        content_box.append (tap_box);
+        content_box.append (scroll_method_label);
+        content_box.append (scroll_method_box);
+        content_box.append (natural_scrolling_box);
+        content_box.append (disable_label);
+        content_box.append (disable_box);
+
+        content_area.attach (content_box, 0, 0);
 
         glib_settings = new GLib.Settings ("org.gnome.desktop.peripherals.touchpad");
         glib_settings.bind (
             "disable-while-typing",
             disable_while_typing_check,
             "active",
-            SettingsBindFlags.DEFAULT
+            DEFAULT
         );
         glib_settings.bind (
             "natural-scroll",
             natural_scrolling_switch,
             "active",
-            SettingsBindFlags.DEFAULT
+            DEFAULT
         );
         glib_settings.bind (
             "speed",
             pointer_speed_adjustment,
             "value",
-            SettingsBindFlags.DEFAULT
+            DEFAULT
         );
         glib_settings.bind (
             "tap-to-click",
             tap_to_click_check,
             "active",
-            SettingsBindFlags.DEFAULT
+            DEFAULT
         );
         glib_settings.bind (
             "tap-and-drag",
             tap_and_drag_check,
             "active",
-            SettingsBindFlags.DEFAULT
+            DEFAULT
         );
         tap_to_click_check.bind_property (
             "active",
@@ -209,7 +195,7 @@ public class MouseTouchpad.TouchpadView : Granite.SimpleSettingsPage {
         );
 
         glib_settings.bind_with_mapping (
-            "send-events", disable_with_mouse_check, "active", SettingsBindFlags.DEFAULT,
+            "send-events", disable_with_mouse_check, "active", DEFAULT,
             (value, variant, user_data) => {
                 value.set_boolean (variant.get_string () == "disabled-on-external-mouse");
                 return true;
@@ -249,7 +235,7 @@ public class MouseTouchpad.TouchpadView : Granite.SimpleSettingsPage {
             group = two_finger_scroll_radio
         };
         disabled_scroll_radio.toggled.connect (() => {
-            natural_scrolling_label.sensitive = !disabled_scroll_radio.active;
+            natural_scrolling_header.sensitive = !disabled_scroll_radio.active;
             natural_scrolling_switch.sensitive = !disabled_scroll_radio.active;
         });
 


### PR DESCRIPTION
Make layout more vertical, use headerlabels, mnemonic widget, secondary text to explain natural scrolling etc. Rearrange to hopefully be a little less visually noisy

![Screenshot from 2024-01-24 12 11 52](https://github.com/elementary/switchboard-plug-mouse-touchpad/assets/7277719/7cedff7e-e03b-4930-a36a-aa203576c9ca)

## BEFORE
![Screenshot from 2024-01-24 12 13 01](https://github.com/elementary/switchboard-plug-mouse-touchpad/assets/7277719/bdd88232-cd4d-474c-a37b-3128d4e1b86d)
